### PR TITLE
(Closes #27) Implement the custom prompt string

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -12,7 +12,6 @@ class CmdApp(Cmd):
         self.abbrev = True
         self.prompt = '[] > '
 
-
     def precmd(self, line):
         if not line.startswith('load') and \
            (line.endswith('.h5') or line.endswith('.hdf5')):
@@ -21,7 +20,9 @@ class CmdApp(Cmd):
 
     def postcmd(self, stop, line):
         if self.explorer:
-            self.prompt = '[{}: {}/] > '.format(os.path.basename(self.explorer.filename), os.path.basename(self.explorer.working_dir))
+            self.prompt = '[{}: {}/] > '.format(
+                os.path.basename(self.explorer.filename),
+                os.path.basename(self.explorer.working_dir))
         return stop
 
     def do_source(self, args):
@@ -34,13 +35,13 @@ class CmdApp(Cmd):
     def do_ls(self, args, opts=None):
         if len(args.strip()) > 0:
             for g in self.explorer.list_groups(args):
-                print(g+"/")
+                print(g + "/")
 
             for ds in self.explorer.list_datasets(args):
                 print(ds)
         else:
             for g in self.explorer.list_groups():
-                print(g+"/")
+                print(g + "/")
 
             for ds in self.explorer.list_datasets():
                 print(ds)

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,13 +6,23 @@ import os
 
 class CmdApp(Cmd):
 
-    Cmd.shortcuts.update({'!': 'bang', '$': 'shell'})
+    def __init__(self):
+        Cmd.__init__(self)
+        Cmd.shortcuts.update({'!': 'bang', '$': 'shell'})
+        self.abbrev = True
+        self.prompt = '[] > '
+
 
     def precmd(self, line):
         if not line.startswith('load') and \
            (line.endswith('.h5') or line.endswith('.hdf5')):
             line = 'load ' + line
         return line
+
+    def postcmd(self, stop, line):
+        if self.explorer:
+            self.prompt = '[{}: {}/] > '.format(os.path.basename(self.explorer.filename), os.path.basename(self.explorer.working_dir))
+        return stop
 
     def do_source(self, args):
         Cmd.do_load(self, args)

--- a/src/h5_wrapper.py
+++ b/src/h5_wrapper.py
@@ -5,6 +5,7 @@ import re
 
 class H5Explorer(object):
     def __init__(self, filename, mode="r"):
+        self.__filename = filename
         self.__file = h5py.File(filename, mode)
         self.__working_dir = "/"
 
@@ -38,6 +39,10 @@ class H5Explorer(object):
     @property
     def working_dir(self):
         return self.__working_dir
+
+    @property
+    def filename(self):
+        return self.__filename
 
     def change_dir(self, new_dir="/"):
         new_dir = self.__check_group(new_dir)


### PR DESCRIPTION
shows up as `[foo.h5: bar/] > ` where foo.h5 is the filename and
bar is the group of the current working directory

In implementing I added \_\_init__ with a one other slight modification
to default behaviour, I have turned abbreviations on, which allows
non-ambiguous commands to be run with the shortest such name

e.g. `history` can be `hist` or `hi` but not `h` because `help` makes
that ambiguous